### PR TITLE
Fix docs typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ save("parabola.gp")  # => save a script file with both data and command to re-cr
 x = -2pi:0.1:2pi
 approx = fill(0., length(x));
 @gp t="Polynomial approximation of sin(x)"  key="opaque" linetypes(:Blues_3)
-@gp :- "set encoding utf8" raw"""set xtics ('-π' -pi, 'π/2' -pi/2, 0, 'π/2' pi/2, 'π' pi)"""
+@gp :- "set encoding utf8" raw"""set xtics ('-π' -pi, '-π/2' -pi/2, 0, 'π/2' pi/2, 'π' pi)"""
 @gp :- xr=3.8.*[-1, 1] yr=[-1.5,1.5] "set grid"
 @gp :- x sin.(x) approx .+=  x          "w filledcurve t 'n=0' lt 1"
 @gp :- x sin.(x) approx .+= -x.^3/6     "w filledcurve t 'n=1' lt 2"

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -14,7 +14,7 @@ saveas(file) = save(term="pngcairo size 550,350 fontscale 0.8", output="assets/$
 ## Options
 The package options are stored in a global structure available in Julia as `Gnuplot.option` (the type of the structure is [`Gnuplot.Options`](@ref)).  The most important settings are as follows:
 
-- `dry::Bool`: if true all new sessions will be started as [Dry sessions](@ref).  Default is `false`, but if the package is not able to start a gnuplot it will automatically switch to `false`;
+- `dry::Bool`: if true all new sessions will be started as [Dry sessions](@ref).  Default is `false`, but if the package is not able to start a gnuplot it will automatically switch to `true`;
 
 - `init::Vector{String}`: initialization commands to be executed when a new session is created.  Default is an empty vector.  It can be used to, e.g., set a custom terminal:
 ```@repl abc


### PR DESCRIPTION
Just a couple of typos in the README and in the docs.