### PR TITLE
Add check for Pluto.jl interactive notebook.

### DIFF
--- a/src/Gnuplot.jl
+++ b/src/Gnuplot.jl
@@ -236,11 +236,12 @@ const sessions = OrderedDict{Symbol, Session}()
 const options = Options()
 
 function __init__()
-    # Check whether we are running in a IJulia or Juno session.
+    # Check whether we are running in an IJulia, Juno or Pluto session.
     # (copied from Gaston.jl).
     options.gpviewer = !(
         ((isdefined(Main, :IJulia)  &&  Main.IJulia.inited)  ||
-         (isdefined(Main, :Juno)    &&  Main.Juno.isactive()))
+         (isdefined(Main, :Juno)    &&  Main.Juno.isactive()) ||
+         (isdefined(Main, :PlutoRunner)) )
     )
 end
 


### PR DESCRIPTION
Enables Gnuplot.jl to work with Pluto.jl 🎈 interactive notebook, by adding in an additional check.