### PR TITLE
VS Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![DocumentationStatus](https://img.shields.io/badge/docs-stable-blue.svg?style=flat)](https://gcalderone.github.io/Gnuplot.jl/v1.3.0/)
 
 
-**Gnuplot.jl** is a simple package able to send both data and commands from Julia to an underlying [gnuplot](http://gnuplot.sourceforge.net/) process.  Its main purpose it to provide a fast and powerful data visualization framework, using an extremely concise Julia syntax. It also has automatic display of plots in both Jupyter and Juno.
+**Gnuplot.jl** is a simple package able to send both data and commands from Julia to an underlying [gnuplot](http://gnuplot.sourceforge.net/) process.  Its main purpose it to provide a fast and powerful data visualization framework, using an extremely concise Julia syntax. It also has automatic display of plots in Jupyter, Juno and VS Code.
 
 
 ## Installation

--- a/src/Gnuplot.jl
+++ b/src/Gnuplot.jl
@@ -236,11 +236,12 @@ const sessions = OrderedDict{Symbol, Session}()
 const options = Options()
 
 function __init__()
-    # Check whether we are running in an IJulia, Juno or Pluto session.
+    # Check whether we are running in an IJulia, Juno, VSCode or Pluto session.
     # (copied from Gaston.jl).
     options.gpviewer = !(
         ((isdefined(Main, :IJulia)  &&  Main.IJulia.inited)  ||
          (isdefined(Main, :Juno)    &&  Main.Juno.isactive()) ||
+         (isdefined(Main, :VSCodeServer)) ||
          (isdefined(Main, :PlutoRunner)) )
     )
 end

--- a/src/Gnuplot.jl
+++ b/src/Gnuplot.jl
@@ -244,6 +244,10 @@ function __init__()
          (isdefined(Main, :VSCodeServer)) ||
          (isdefined(Main, :PlutoRunner)) )
     )
+    if isdefined(Main, :VSCodeServer)
+        # VS Code shows "dynamic" plots with fixed and small size :-(
+        options.mime[MIME"image/svg+xml"] = replace(options.mime[MIME"image/svg+xml"], "dynamic" => "")
+    end
 end
 
 


### PR DESCRIPTION
This adds support for displaying plots in VS Code internal viewer. For more details see the commit messages of individual commits.

Screenshot:
![image](https://user-images.githubusercontent.com/140542/113037054-480e8d80-9195-11eb-89fc-ec24641ef081.png)

Related to #31