### PR TITLE
Use the VS Code internal viewer only of the plot pane is enabled

### DIFF
--- a/src/Gnuplot.jl
+++ b/src/Gnuplot.jl
@@ -241,7 +241,7 @@ function __init__()
     options.gpviewer = !(
         ((isdefined(Main, :IJulia)  &&  Main.IJulia.inited)  ||
          (isdefined(Main, :Juno)    &&  Main.Juno.isactive()) ||
-         (isdefined(Main, :VSCodeServer)) ||
+         (isdefined(Main, :VSCodeServer) && Main.VSCodeServer.PLOT_PANE_ENABLED[]) ||
          (isdefined(Main, :PlutoRunner)) )
     )
     if isdefined(Main, :VSCodeServer)


### PR DESCRIPTION
When the plot pane is disabled, VS Code neither shows the plot nor
prints any warning/error. The plot is not shown because Gnuplot.jl
thinks the VS Code can display it. We fix that by adding a check for
whether the pane is enabled.

This is not an ideal solution because the check is executed only when
loading Gnuplot.jl. If the panel is disabled later in the REPL
session, no plots will be shown. If this turns out to be a problem, we
will need to extend `showable` and perform the check there.

The problem of not showing a warning/error when the plot pane is
disabled must be addressed in julia-vscode. It seems that the Plots
package doesn't produce any warning/error in this case too.

Related to #45.