### PR TITLE
Allow using single quotes in output file names

### DIFF
--- a/src/Gnuplot.jl
+++ b/src/Gnuplot.jl
@@ -925,7 +925,7 @@ function execall(gp::GPSession; term::AbstractString="", output::AbstractString=
         gpexec(gp, "unset multiplot")
         gpexec(gp, "set term $term")
     end
-    (output != "")  &&  gpexec(gp, "set output '$output'")
+    (output != "")  &&  gpexec(gp, "set output '$(replace(output, "'" => "''"))'")
 
     # printstyled("Plotting with terminal: " * terminal() * "\n", color=:blue, bold=true)
 


### PR DESCRIPTION
Gnuplot single-quoted strings have to escape single-quote characters
by doubling them.