### PR TITLE
Run CI on `master` branch instead of `main`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
My bad. #56 doesn't run anything after merging because the "main" branch is `master` at this repository.